### PR TITLE
Add SerpApi as alternative reverse image search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reverse Image Search Web App
 
-This project provides a simple web interface to upload an image and search for similar images on the internet. The search relies on an external image search API (for example, Bing Visual Search). You must supply your own API key and endpoint in environment variables `BING_VISUAL_SEARCH_KEY` and `BING_VISUAL_SEARCH_ENDPOINT`.
+This project provides a simple web interface to upload an image and search for similar images on the internet. The search relies on an external image search API. By default Bing Visual Search is used, but you can also use SerpApi (Google Lens). Supply the appropriate credentials via environment variables.
 
 ## Setup
 
@@ -10,12 +10,19 @@ This project provides a simple web interface to upload an image and search for s
 pip install -r requirements.txt
 ```
 
-2. Export your API credentials:
+2. Export your API credentials. You can configure either Bing Visual Search or SerpApi:
 
 ```bash
+# For Bing
 export BING_VISUAL_SEARCH_KEY=your_key
 export BING_VISUAL_SEARCH_ENDPOINT="https://api.bing.microsoft.com/v7.0/images/visualsearch"
+
+# Or for SerpApi (Google Lens)
+export SERPAPI_KEY=your_serpapi_key
+export SERPAPI_ENDPOINT="https://serpapi.com/search"
 ```
+
+If `SERPAPI_KEY` is set, the application will use SerpApi. Otherwise it falls back to Bing Visual Search.
 
 3. Run the server:
 


### PR DESCRIPTION
## Summary
- support SerpApi in `search_image` for reverse image search
- document usage of SerpApi or Bing in README

## Testing
- `python -m py_compile run_webapp.py webapp/server.py`