### PR TITLE
Add configuration file support for API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for the web app
+BING_VISUAL_SEARCH_KEY=your_key
+BING_VISUAL_SEARCH_ENDPOINT=https://api.bing.microsoft.com/v7.0/images/visualsearch
+SERPAPI_KEY=your_serpapi_key
+SERPAPI_ENDPOINT=https://serpapi.com/search

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore environment and config files containing secrets
+.env
+config.py
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ This project provides a simple web interface to upload an image and search for s
 pip install -r requirements.txt
 ```
 
-2. Export your API credentials. You can configure either Bing Visual Search or SerpApi:
+2. Provide your API credentials. You can configure either Bing Visual Search or SerpApi. There are two ways to supply the keys:
+
+   * **Environment variables** (existing behaviour)
+   * **Configuration file**: copy `config_example.py` to `config.py` and edit it with your credentials. This file is ignored by git.
+   * **.env file**: create a `.env` file with the same variables if you prefer keeping them outside the code.
 
 ```bash
 # For Bing

--- a/config_example.py
+++ b/config_example.py
@@ -1,0 +1,10 @@
+# Example configuration file for API keys.
+# Copy this file to config.py and replace the placeholder values with your credentials.
+
+# Bing Visual Search
+BING_VISUAL_SEARCH_KEY = "your_bing_key"
+BING_VISUAL_SEARCH_ENDPOINT = "https://api.bing.microsoft.com/v7.0/images/visualsearch"
+
+# SerpApi (Google Lens)
+SERPAPI_KEY = "your_serpapi_key"
+SERPAPI_ENDPOINT = "https://serpapi.com/search"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 requests
 Pillow
+python-dotenv

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -3,6 +3,23 @@ from flask import Flask, render_template, request, jsonify
 from PIL import Image
 import requests
 from io import BytesIO
+from dotenv import load_dotenv
+
+try:
+    import config  # local configuration (not tracked in git)
+except ImportError:  # pragma: no cover - config is optional
+    config = None
+
+load_dotenv()
+
+def get_setting(name, default=None):
+    """Return configuration from environment or optional config module."""
+    value = os.environ.get(name)
+    if value:
+        return value
+    if config and hasattr(config, name):
+        return getattr(config, name)
+    return default
 
 app = Flask(__name__)
 
@@ -10,8 +27,8 @@ app = Flask(__name__)
 
 def search_image_bing(image_bytes):
     """Search similar images using Bing Visual Search."""
-    api_key = os.environ.get('BING_VISUAL_SEARCH_KEY')
-    endpoint = os.environ.get('BING_VISUAL_SEARCH_ENDPOINT')
+    api_key = get_setting('BING_VISUAL_SEARCH_KEY')
+    endpoint = get_setting('BING_VISUAL_SEARCH_ENDPOINT')
     if not api_key or not endpoint:
         return []
 
@@ -38,8 +55,8 @@ def search_image_bing(image_bytes):
 
 def search_image_serpapi(image_bytes):
     """Search similar images using SerpApi (Google Lens)."""
-    api_key = os.environ.get('SERPAPI_KEY')
-    endpoint = os.environ.get('SERPAPI_ENDPOINT', 'https://serpapi.com/search')
+    api_key = get_setting('SERPAPI_KEY')
+    endpoint = get_setting('SERPAPI_ENDPOINT', 'https://serpapi.com/search')
     if not api_key:
         return []
 
@@ -67,7 +84,7 @@ def search_image_serpapi(image_bytes):
 
 def search_image(image_bytes):
     """Call the configured external API to search for similar images."""
-    if os.environ.get('SERPAPI_KEY'):
+    if get_setting('SERPAPI_KEY'):
         return search_image_serpapi(image_bytes)
     return search_image_bing(image_bytes)
 


### PR DESCRIPTION
## Summary
- load environment variables from `.env` and optional `config.py`
- update server code to read API credentials from config
- document new options in the README
- provide example `.env` and `config_example.py`
- ignore secrets via `.gitignore`

## Testing
- `python -m py_compile webapp/server.py`
