### PR TITLE
Add custom domain instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,26 @@ opens your default browser automatically:
 python run_webapp.py
 ```
 
+### Using a custom local domain
+
+If you want to access the web app with a custom name such as
+`https://recherche-image.com`, map this domain to your machine in your
+`/etc/hosts` file:
+
+```bash
+127.0.0.1 recherche-image.com
+```
+
+Run the server with HTTPS enabled:
+
+```bash
+HOST=0.0.0.0 PORT=5000 HTTPS=1 python webapp/server.py
+```
+
+Then open `https://recherche-image.com:5000` in your browser. The Flask
+development server uses a self-signed certificate, so your browser may display a
+warning that you need to accept.
+
 ## Limitations
 
 - This project uses an external API for image search. You may need to sign up for a key. Free tiers may have usage limits.

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -111,4 +111,10 @@ def search():
     return jsonify(results)
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    host = os.environ.get('HOST', '127.0.0.1')
+    port = int(os.environ.get('PORT', 5000))
+    use_https = os.environ.get('HTTPS') == '1'
+    if use_https:
+        app.run(host=host, port=port, debug=True, ssl_context='adhoc')
+    else:
+        app.run(host=host, port=port, debug=True)


### PR DESCRIPTION
## Summary
- support custom host, port, and HTTPS for the dev server
- document how to map a custom domain for local development

## Testing
- `python -m py_compile webapp/server.py run_webapp.py config_example.py`
- `pytest -q` *(fails: command not found)*